### PR TITLE
Correct String#includes example results

### DIFF
--- a/chapters/ch08.asciidoc
+++ b/chapters/ch08.asciidoc
@@ -881,9 +881,9 @@ You can also provide +String#includes+ with a start index where searching should
 [source,javascript]
 ----
 `hello gary`.includes(`ga`, 4);
-// <- false
-`hello gary`.includes(`ga`, 7);
 // <- true
+`hello gary`.includes(`ga`, 7);
+// <- false
 ----
 
 Let's move onto something that's not just an +String#indexOf+ alternative.


### PR DESCRIPTION
Hi, this is a Pull Request to correct the results of the last example In `8.3.3 String#includes`.

Before:

``` javascript
`hello gary`.includes(`ga`, 4);
// <- false
`hello gary`.includes(`ga`, 7);
// <- true
```

After:

``` javascript
`hello gary`.includes(`ga`, 4);
// <- true
`hello gary`.includes(`ga`, 7);
// <- false
```
