### PR TITLE
Add comma separator for rest parameters section

### DIFF
--- a/chapters/ch03.asciidoc
+++ b/chapters/ch03.asciidoc
@@ -706,7 +706,7 @@ Named parameters before the rest parameter won't be included in the +list+.
 
 [source,javascript]
 ----
-function print (first ...list) {
+function print (first, ...list) {
   console.log(first);
   console.log(list);
 }


### PR DESCRIPTION
I know it's trivial, but the example doesn't work in Chrome for me! Woohooo open source!
