### PR TITLE
Fixes 'Uncaught ReferenceError: prefix is not defined' in an example in chapter 6 (last example in section 6.1.2).

### DIFF
--- a/chapters/ch06.asciidoc
+++ b/chapters/ch06.asciidoc
@@ -167,12 +167,12 @@ function concealWithPrefix (original, prefix='_') {
       return Reflect.set(original, key, value)
     }
   }
+  return new Proxy(original, handler)
   function invariant (key, action) {
     if (key.startsWith(prefix)) {
       throw new Error(`Invalid attempt to ${ action } private "${ key }" property`)
     }
   }
-  return new Proxy(original, handler)
 }
 const target = {
   _secret: 'secret',

--- a/chapters/ch06.asciidoc
+++ b/chapters/ch06.asciidoc
@@ -159,20 +159,20 @@ A general purpose approach would be to offer a proxying function that takes an +
 function concealWithPrefix (original, prefix='_') {
   const handler = {
     get (original, key) {
-      invariant(key, 'get', prefix)
+      invariant(key, 'get')
       return Reflect.get(original, key)
     },
     set (original, key, value) {
-      invariant(key, 'set', prefix)
+      invariant(key, 'set')
       return Reflect.set(original, key, value)
     }
   }
-  return new Proxy(original, handler)
-}
-function invariant (key, action, prefix) {
-  if (key.startsWith(prefix)) {
-    throw new Error(`Invalid attempt to ${ action } private "${ key }" property`)
+  function invariant (key, action) {
+    if (key.startsWith(prefix)) {
+      throw new Error(`Invalid attempt to ${ action } private "${ key }" property`)
+    }
   }
+  return new Proxy(original, handler)
 }
 const target = {
   _secret: 'secret',

--- a/chapters/ch06.asciidoc
+++ b/chapters/ch06.asciidoc
@@ -159,17 +159,17 @@ A general purpose approach would be to offer a proxying function that takes an +
 function concealWithPrefix (original, prefix='_') {
   const handler = {
     get (original, key) {
-      invariant(key, 'get')
+      invariant(key, 'get', prefix)
       return Reflect.get(original, key)
     },
     set (original, key, value) {
-      invariant(key, 'set')
+      invariant(key, 'set', prefix)
       return Reflect.set(original, key, value)
     }
   }
   return new Proxy(original, handler)
 }
-function invariant (key, action) {
+function invariant (key, action, prefix) {
   if (key.startsWith(prefix)) {
     throw new Error(`Invalid attempt to ${ action } private "${ key }" property`)
   }


### PR DESCRIPTION
`Prefix` isn't defined in the scope it's used in.