### PR TITLE
Fix missing `+` in getCarProductModel

### DIFF
--- a/chapters/ch02.asciidoc
+++ b/chapters/ch02.asciidoc
@@ -705,7 +705,7 @@ When we destructure everything up front, it's easy to spot when input doesn't ad
 [source,javascript]
 ----
 var getCarProductModel = ({ brand, make, model }) => ({
-  sku: brand + ':' make + ':' + model,
+  sku: brand + ':' + make + ':' + model,
   brand,
   make,
   model


### PR DESCRIPTION
Fix missing `+` for concatenation otherwise the `getCarProductModel` can't be initialized