### PR TITLE
escape the * of the generator function note to fix formatting

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -1068,7 +1068,7 @@ Generators ((("generators", id="gen4")))are a new feature in ES6. The way they w
 
 We ((("generators", "fundamentals", id="gen4f")))already examined iterators in the previous section, learning how their `.next()` method is called one at a time to pull values from a sequence. Instead of a `next` method whenever you return a value, generators use the `yield` ((("yield")))keyword to add values into the sequence.
 
-Here is an example generator function. Note the `*` after `function`. That's ((("function*")))not a typo, that's how you mark a generator function as a generator.
+Here is an example generator function. Note the `+*+` after `function`. That's ((("function*")))not a typo, that's how you mark a generator function as a generator.
 
 [source,javascript]
 ----


### PR DESCRIPTION
Reading this chapter on github in asciidoc format, I found that in the beginning of the "Generator Functions and Generator Objects* section, a "*" was not escaped properly, so that the rest of the text was rendered bold:
![grafik](https://user-images.githubusercontent.com/1146131/29250617-ddb078ae-8045-11e7-96d2-f3f7ab05e9de.png)

Checking locally with asciidoctor, only the rest of the line was rendered bold:
![grafik](https://user-images.githubusercontent.com/1146131/29250625-fdce023c-8045-11e7-95d1-cf70b259f3e5.png)

I have added an escape sequence to properly show the "*" and not have anything rendered in bold, that shouldn't.
