### PR TITLE
fix babel-preset-env version ref

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -147,7 +147,7 @@ To install Babel, enter the following couple of commands into your favorite term
 [source,shell]
 ----
 npm install babel-cli​@6 --save-dev
-npm install babel-preset-env@6 --save-dev
+npm install babel-preset-env@1 --save-dev
 ----
 
 [NOTE]


### PR DESCRIPTION
I guess there is a typo here. github says there never was a version 6 of `babel-preset-env`