### PR TITLE
Typo: self => this

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -802,7 +802,7 @@ const pistol = {
   caliber: 50,
   trigger() {
     setTimeout(() => {
-      console.log(`Fired caliber ${ self.caliber } pistol`)
+      console.log(`Fired caliber ${ this.caliber } pistol`)
     }, 1000)
   }
 }


### PR DESCRIPTION
I believe we have a typo here.

The previous code outputs "Fired caliber undefined pistol"

The modified code outputs "Fired caliber 50 pistol"