### PR TITLE
ch02: fix possible typo in destructuring use case

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -745,7 +745,7 @@ console.log(random({ max: 24 }))
 // <- 18
 ----
 
-Regular ((("assignment destructuring", "function parameters", startref="ad2fpd")))((("destructuring", "function parameters", startref="d2fpd")))((("function parameters", startref="fpd2")))expressions are another great fit for destructuring. Destructuring empowers you to name groups from a match without having to resort to index numbers. Here's an example `RegExp` that could be used for parsing simple dates, and an example of destructuring those dates into each of their components. The first entry in the resulting array is reserved for the raw input string, and we can discard it.
+Regular ((("assignment destructuring", "function parameters", startref="ad2fpd")))((("destructuring", "function parameters", startref="d2fpd")))((("function parameters", startref="fpd2")))expressions are another great fit for destructuring. Destructuring empowers you to name groups from a match without having to resort to index numbers. Here's an example `RegExp` that could be used for parsing simple dates, and an example of destructuring those dates into each of their components. The first entry in the resulting array is reserved for the full matched text, and we can discard it.
 
 [source,javascript]
 ----


### PR DESCRIPTION
"The first entry in the resulting array is reserved for the **raw input string**..."
->
"The first entry in the resulting array is reserved for the **full matched text**..."
