### PR TITLE
Fix 'Scheme validation with proxies'

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -205,7 +205,7 @@ const validations = new Map()
 const validator = {
   set(target, key, value) {
     if (validations.has(key)) {
-      return validations[key](value)
+      validations.get(key)(value)
     }
     return Reflect.set(target, key, value)
   }


### PR DESCRIPTION
mjavascript#49
* proper access to Map property through `get`, because `[]` dont work with Map objects
* dont return validation function result, just run validation, because all properties that have validation functions won't be written in target object
